### PR TITLE
Initial support for fuzzing

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "floatconv-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.floatconv]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "hard_u128_to_f64_round"
+path = "fuzz_targets/hard_u128_to_f64_round.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/hard_u128_to_f64_round.rs
+++ b/fuzz/fuzz_targets/hard_u128_to_f64_round.rs
@@ -1,0 +1,6 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: u128| {
+    assert_eq!(floatconv::fast::u128_to_f64_round(data), data as f64);
+});


### PR DESCRIPTION
Initial support for fuzzing.

Since the crate does not have any unsafe code, the fuzzing can be run without Address Sanitizer for a bit of a speed boost: `cargo +nightly fuzz run hard_u128_to_f64_round`

I'm not convinced that this is better than a dumb RNG in this case, since fuzzing relies on branches for making decisions about the input, and there isn't a lot of branches in this code.